### PR TITLE
Added install target for openspin binary

### DIFF
--- a/qmake/openspin.pro
+++ b/qmake/openspin.pro
@@ -51,3 +51,9 @@ HEADERS += \
     ../SpinSource/preprocess.h \
     ../SpinSource/textconvert.h
 
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+
+target.path = $$PREFIX/bin
+INSTALLS += target


### PR DESCRIPTION
This adds an install target to the generated Makefile. flatpak builder uses the install target to place the files in the right location inside the flatpak.